### PR TITLE
Fix `FilesService.Upload`

### DIFF
--- a/client.go
+++ b/client.go
@@ -18,11 +18,11 @@ const (
 )
 
 const (
-	defaultUserAgent = "go-putio"
-	defaultMediaType = "application/json"
-	defaultBaseURL   = "https://api.put.io"
-	defaultUploadURL = "https://upload.put.io"
-	defaultTusURL    = "https://upload.put.io/files/"
+	defaultUserAgent  = "go-putio"
+	defaultMediaType  = "application/json"
+	defaultBaseURL    = "https://api.put.io"
+	defaultUploadHost = "upload.put.io"
+	defaultTusURL     = "https://upload.put.io/files/"
 )
 
 // Client manages communication with Put.io v2 API.
@@ -109,17 +109,16 @@ func (c *Client) NewRequest(ctx context.Context, method, relURL string, body io.
 		return nil, fmt.Errorf("%w", err)
 	}
 
+	u := c.BaseURL.ResolveReference(rel)
+
 	// Workaround for upload endpoints. Upload server is different than API server.
-	var u *url.URL
 	switch {
-	case relURL == "$upload$":
-		u, _ = url.Parse(defaultUploadURL)
+	case relURL == "/v2/files/upload":
+		u.Host = defaultUploadHost
 	case relURL == "$upload-tus$":
 		u, _ = url.Parse(defaultTusURL)
 	case strings.HasPrefix(relURL, "http://") || strings.HasPrefix(relURL, "https://"):
 		u = rel
-	default:
-		u = c.BaseURL.ResolveReference(rel)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, method, u.String(), body)

--- a/client_test.go
+++ b/client_test.go
@@ -64,3 +64,33 @@ func TestNewRequest_customUserAgent(t *testing.T) {
 		t.Errorf("got: %v, want: %v", got, userAgent)
 	}
 }
+
+func TestNewRequest_resolveAbsoluteUrl(t *testing.T) {
+	cl := NewClient(nil)
+	fullUrl := "https://api.put.io/v2/files/list/continue"
+
+	req, _ := cl.NewRequest(context.Background(), http.MethodGet, "/v2/files/list/continue", nil)
+	if got := req.URL.String(); got != fullUrl {
+		t.Errorf("got: %v, want: %v", got, fullUrl)
+	}
+}
+
+func TestNewRequest_overrideBaseUrl(t *testing.T) {
+	cl := NewClient(nil)
+	fullUrl := "https://upload.put.io/v2/files/upload"
+
+	req, _ := cl.NewRequest(context.Background(), http.MethodGet, "/v2/files/upload", nil)
+	if got := req.URL.String(); got != fullUrl {
+		t.Errorf("got: %v, want: %v", got, fullUrl)
+	}
+}
+
+func TestNewRequest_overrideWithAbsoluteUrl(t *testing.T) {
+	cl := NewClient(nil)
+	fullUrl := "https://my-custom-url.com/endpoint?query=param"
+
+	req, _ := cl.NewRequest(context.Background(), http.MethodGet, "https://my-custom-url.com/endpoint?query=param", nil)
+	if got := req.URL.String(); got != fullUrl {
+		t.Errorf("got: %v, want: %v", got, fullUrl)
+	}
+}

--- a/files.go
+++ b/files.go
@@ -243,7 +243,7 @@ func (f *FilesService) Upload(ctx context.Context, r io.Reader, filename string,
 		return Upload{}, fmt.Errorf("%w", err)
 	}
 
-	req, err := f.client.NewRequest(ctx, http.MethodPost, "$upload$", &buf)
+	req, err := f.client.NewRequest(ctx, http.MethodPost, "/v2/files/upload", &buf)
 	if err != nil {
 		return Upload{}, fmt.Errorf("%w", err)
 	}


### PR DESCRIPTION
Hey there,
in this GitRepo you do not have the "Issues" activated to report a potential bug so I tried to investigate myself.

For me, the `FilesService.Upload` does not work correctly. 
```
putio error. code:404 type:"" message:"" request:POST https://upload.put.io
```

After investigating, I found out that according to the [API specifications of putio](https://app.swaggerhub.com/apis-docs/putio/putio/2.8.11#/files/post_files_upload) the Endpoint to upload should be `https://upload.put.io/v2/files/upload` instead of just `https://upload.put.io`. This is what the code is doing. Until now, we're using a weird placeholder `$upload$` to override the hostname. I improved the logic, made clearer what is happening and added tests to the `client`

I did not touch the logic of `func (u *UploadService) CreateUpload(` this uses a weird placeholder as well. I do not know where this endpoint is reflected in V2 at all, so I kept the logic as is here