### PR TITLE
Handle invalid OAuth token validation responses

### DIFF
--- a/client.go
+++ b/client.go
@@ -92,11 +92,18 @@ func (c *Client) ValidateToken(ctx context.Context) (userID *int64, err error) {
 		return
 	}
 	var r struct {
+		Result *bool  `json:"result"`
 		UserID *int64 `json:"user_id"`
 	}
 	_, err = c.Do(req, &r) // nolint:bodyclose
 	if err != nil {
 		return nil, err
+	}
+	if r.Result != nil && !*r.Result {
+		return nil, ErrInvalidToken
+	}
+	if r.UserID == nil {
+		return nil, ErrInvalidToken
 	}
 	return r.UserID, nil
 }

--- a/client_test.go
+++ b/client_test.go
@@ -2,6 +2,7 @@ package putio
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -71,4 +72,60 @@ func TestNewRequest_customUserAgent(t *testing.T) {
 	if got := req.Header.Get("User-Agent"); got != userAgent {
 		t.Errorf("got: %v, want: %v", got, userAgent)
 	}
+}
+
+func TestValidateToken(t *testing.T) {
+	t.Run("valid token", func(t *testing.T) {
+		setup()
+		defer teardown()
+
+		mux.HandleFunc("/v2/oauth2/validate", func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, http.MethodGet)
+			_, _ = w.Write([]byte(`{"result":true,"user_id":123}`))
+		})
+
+		got, err := client.ValidateToken(context.Background())
+		if err != nil {
+			t.Fatalf("ValidateToken returned error: %v", err)
+		}
+		if got == nil || *got != 123 {
+			t.Fatalf("ValidateToken userID = %v, want 123", got)
+		}
+	})
+
+	t.Run("invalid token result", func(t *testing.T) {
+		setup()
+		defer teardown()
+
+		mux.HandleFunc("/v2/oauth2/validate", func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, http.MethodGet)
+			_, _ = w.Write([]byte(`{"result":false,"token_id":null,"token_scope":null,"user_id":null}`))
+		})
+
+		got, err := client.ValidateToken(context.Background())
+		if got != nil {
+			t.Fatalf("ValidateToken userID = %v, want nil", got)
+		}
+		if !errors.Is(err, ErrInvalidToken) {
+			t.Fatalf("ValidateToken error = %v, want %v", err, ErrInvalidToken)
+		}
+	})
+
+	t.Run("missing user id", func(t *testing.T) {
+		setup()
+		defer teardown()
+
+		mux.HandleFunc("/v2/oauth2/validate", func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, http.MethodGet)
+			_, _ = w.Write([]byte(`{}`))
+		})
+
+		got, err := client.ValidateToken(context.Background())
+		if got != nil {
+			t.Fatalf("ValidateToken userID = %v, want nil", got)
+		}
+		if !errors.Is(err, ErrInvalidToken) {
+			t.Fatalf("ValidateToken error = %v, want %v", err, ErrInvalidToken)
+		}
+	})
 }

--- a/error.go
+++ b/error.go
@@ -19,6 +19,7 @@ var (
 	ErrNoFileIsGiven            = errors.New("no files given")
 	ErrEmptyUserName            = errors.New("empty username")
 	ErrEmptyURL                 = errors.New("empty URL")
+	ErrInvalidToken             = errors.New("invalid token")
 	ErrUnexpected               = errors.New("unexpected error")
 )
 


### PR DESCRIPTION
## What

Treat `ValidateToken` responses with `result:false` as invalid tokens instead of returning `(nil, nil)`. Also return `ErrInvalidToken` when the validation response has no `user_id`.

## Why

The Put.io OAuth validation endpoint can return HTTP 200 with a payload like:

```json
{"result":false,"token_id":null,"token_scope":null,"user_id":null}
```

The current client only decodes `user_id`, so callers see `(nil, nil)` and have to guess whether the token is invalid or the response is malformed. Returning a sentinel error gives callers a reliable path for stale/invalid tokens.

## Compatibility

The `ValidateToken` signature is unchanged. Valid responses still return the user ID. Invalid or missing-user responses now return `ErrInvalidToken` instead of `(nil, nil)`.

## Tests

- `go test ./...`