### PR TITLE
ci: add automated release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,6 @@ on:
   push:
     branches:
       - master
-      - main
-    tags:
-      - "v*"
   workflow_dispatch:
 
 permissions:
@@ -63,3 +60,32 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           version: v2.11.3
+
+  release:
+    name: Release Go module
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master' && !contains(github.event.head_commit.message, '[skip ci]')
+    needs:
+      - test
+      - quality
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: release-${{ github.repository }}-master
+      cancel-in-progress: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Release
+        uses: cycjimmy/semantic-release-action@v6
+        with:
+          extra_plugins: |
+            @semantic-release/commit-analyzer
+            @semantic-release/release-notes-generator
+            @semantic-release/github
+            conventional-changelog-conventionalcommits
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,24 @@
+{
+  "branches": ["master"],
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "successComment": false,
+        "failComment": false
+      }
+    ]
+  ]
+}

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,46 @@
+# Release
+
+## Delivery Model
+
+Every merge to `master` should already be releasable.
+
+GitHub Actions owns releases for this repo. The workflow verifies the Go module first, then runs semantic-release on `master`.
+
+The release lane:
+
+- reads Conventional Commits since the latest `v*` tag
+- calculates the next semantic version
+- creates the git tag
+- creates the GitHub Release and generated notes
+
+Go modules are published by git tag, so this repo does not build or upload package artifacts. It does not use GoReleaser because there are no binaries to publish.
+
+## Required Tokens
+
+The release job uses the built-in GitHub Actions bot token:
+
+- `GITHUB_TOKEN`
+
+No custom secret is required. The job grants `contents: write` only so semantic-release can create tags and GitHub Releases in this repository.
+
+## Versioning
+
+Conventional Commits drive automated version selection:
+
+- `fix:` creates a patch release
+- `feat:` creates a minor release
+- `feat!:` or `BREAKING CHANGE:` creates a major release
+- `ci:`, `docs:`, `test:`, and `chore:` do not create a release by default
+
+The current release branch is `master`.
+
+## Local Checks
+
+Before changing release wiring, validate the repo-local guardrails:
+
+```bash
+go test -v ./...
+go test -race -count=1 ./...
+golangci-lint run ./...
+actionlint
+```


### PR DESCRIPTION
Changed
- Adds semantic-release config for tag-only Go module releases on `master`.
- Adds a release job after the existing test and quality jobs pass.
- Uses only the built-in GitHub Actions bot token with `contents: write` permission.
- Removes tag-triggered CI runs so release-created tags do not cause duplicate workflow runs.
- Documents the release model in `docs/RELEASE.md`.

Risks
- The first merge after this lands should create `v1.7.3` because `fix: improve ValidateToken invalid response handling (#8)` is still newer than the latest `v1.7.2` tag.
- semantic-release is configured for `master`, matching the current repository branch.
- No GoReleaser or package-registry publishing is configured; Go module publishing remains git-tag based.

Complexity
- Neutral: release automation is isolated to GitHub Actions, `.releaserc.json`, and release docs.

Verification
- actionlint
- mise exec go@1.26.2 -- go test -v ./...
- mise exec go@1.26.2 -- go test -race -count=1 ./...
- mise exec go@1.26.2 golangci-lint@2.11.3 -- golangci-lint run ./...
- jq . .releaserc.json