### PR TITLE
ci: use putio-releaser for releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,12 @@ jobs:
     needs:
       - test
       - quality
+    environment:
+      name: release
+      deployment: false
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     concurrency:
       group: release-${{ github.repository }}-master
       cancel-in-progress: false
@@ -78,6 +81,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - name: Mint release token
+        id: release-bot
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.PUTIO_RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.PUTIO_RELEASE_BOT_PRIVATE_KEY }}
+          permission-contents: write
 
       - name: Release
         uses: cycjimmy/semantic-release-action@v6
@@ -88,4 +99,4 @@ jobs:
             @semantic-release/github
             conventional-changelog-conventionalcommits
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.release-bot.outputs.token }}


### PR DESCRIPTION
## Summary

Replace the release jobs default `GITHUB_TOKEN` authentication with a least-privilege `putio-releaser` installation token.

## Changed

- scope release credentials to the approval-free `release` Environment restricted to `master`
- mint a token with only Contents write access using SHA-pinned `actions/create-github-app-token@v3.2.0`
- pass the minted token to semantic-release as `GITHUB_TOKEN`
- keep the default job token at Contents read

## Review aids

```mermaid
flowchart LR
  A[Trusted master push] --> B[release Environment]
  B --> C[Mint Contents-write App token]
  C --> D[semantic-release]
```

No Issues or Pull Requests permission is requested.

## Risks

The trusted `master` run is the only runtime proof of App-token minting. Merge with a conventional `ci:` commit message and do not add `[skip ci]`; the expected result for this authentication-only change is successful token minting followed by semantic-releases no-release path.

## Verification

- `actionlint .github/workflows/ci.yml`
- `uvx zizmor .` (same pre-existing findings as `origin/master`: 3 artipacked, 7 unpinned action references in the workflow; the added action is SHA-pinned)
- `go test ./...`
- `go test -race ./...`
- release Environment, branch policy, variable metadata, and secret metadata read back through the GitHub API

## Complexity

Small, isolated release-authentication change.